### PR TITLE
[loki] Allow public access over http

### DIFF
--- a/loki/main.tf
+++ b/loki/main.tf
@@ -7,7 +7,7 @@ module "loki" {
   instance_flavor = var.loki_instance_flavor
   ssh             = var.ssh
   userdata_path   = "../userdata.yml"
-  security_groups = ["ssh_security_group"]
+  security_groups = ["ssh_security_group", "loki_security_group"]
 
   instance_metadata = {
     role = "loki"

--- a/loki/secgroup.tf
+++ b/loki/secgroup.tf
@@ -1,0 +1,16 @@
+resource "openstack_networking_secgroup_v2" "loki_security_group" {
+  name        = "loki_security_group"
+  description = "loki security group"
+  tags        = []
+}
+
+resource "openstack_networking_secgroup_rule_v2" "loki" {
+  for_each          = toset(var.ui_ingress)
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 3100
+  port_range_max    = 3100
+  remote_ip_prefix  = each.value
+  security_group_id = openstack_networking_secgroup_v2.loki_security_group.id
+}

--- a/playbook/group_vars/meta-role_loki/loki.yml
+++ b/playbook/group_vars/meta-role_loki/loki.yml
@@ -5,7 +5,6 @@ loki_bins:
   - promtail
   - logcli
 
-loki_listen_address: "{{ private_ip }}"
 loki_server_config:
-  http_listen_address: "{{ loki_listen_address }}"
+  http_listen_address: 0.0.0.0
   grpc_listen_address: 127.0.0.1


### PR DESCRIPTION
Troubleshooting starts to get harder, having all logs available in the
shell just like tail would be nice.

Signed-off-by: Wilfried Roset <wilfriedroset@users.noreply.github.com>